### PR TITLE
Initialize schema types

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -2,6 +2,225 @@
 ### Do not make changes to this file directly
 
 
+"""Returned when a user logs in our logs out."""
+type AuthPayload {
+  """Optional error message if success is false"""
+  message: String
+
+  """Whether auth operation was successful or not"""
+  success: Boolean!
+
+  """Auth token used for future requests"""
+  token: String!
+}
+
+input ChangeUserPasswordInput {
+  currentPassword: String!
+  newPassword: String!
+}
+
+type CourseID {
+  """Course code, e.g. 499, 310"""
+  code: String!
+
+  """Course subject, e.g. SENG, CSC"""
+  subject: String!
+
+  """Term course is offered in"""
+  term: Term!
+}
+
+type CoursePreference {
+  id: CourseID!
+  preference: Int!
+}
+
+"""
+A set of CourseSections with matching CourseID represent a course offering
+"""
+type CourseSection {
+  """The course identifier"""
+  CourseID: CourseID!
+
+  """Maximum capacity of the section"""
+  capacity: Int!
+
+  """The end date of the course"""
+  endDate: Date!
+
+  """How many hours per week a course takes"""
+  hoursPerWeek: Float!
+
+  """Days of the week the class is offered in - see Day"""
+  meetingTimes: [MeetingTime!]!
+
+  """Professor's info, if any professors are assigned"""
+  professors: [User!]
+
+  """The start date of the course"""
+  startDate: Date!
+}
+
+type CreateUserMutationResult {
+  message: String
+  password: String
+  success: Boolean!
+  username: String
+}
+
+scalar Date
+
+"""Days of the Week"""
+enum Day {
+  FRIDAY
+  MONDAY
+  SATURDAY
+  SUNDAY
+  THURSDAY
+  TUESDAY
+  WEDNESDAY
+}
+
+type Error {
+  errors: [Error!]
+  message: String!
+}
+
+input GenerateScheduleInput {
+  year: Int!
+}
+
+"""Weekday and time of a course section offering"""
+type MeetingTime {
+  """Weekday - see DayEnum"""
+  day: Day!
+
+  """End time"""
+  endTime: Date!
+
+  """Start time"""
+  startTime: Date!
+}
+
+type Mutation {
+  """Change the password of the currently logged in user"""
+  changeUserPassword(input: ChangeUserPasswordInput!): Response!
+
+  """Register a new user account"""
+  createUser(username: String!): CreateUserMutationResult!
+
+  """Generate schedule"""
+  generateSchedule(input: GenerateScheduleInput!): Response!
+
+  """Login into a user account using email and password"""
+  login(password: String!, username: String!): AuthPayload!
+
+  """Logout the currently logged in user"""
+  logout: AuthPayload!
+
+  """Reset a users password."""
+  resetPassword(id: ID!): ResetPasswordMutationResult!
+
+  """Updates a user given the user id."""
+  updateUser(input: UpdateUserInput!): UpdateUserMutationResult
+}
+
 type Query {
-  ok: Boolean!
+  """Get a list of courses for a given term"""
+  courses(term: Term): [CourseSection!]
+
+  """Find a user by their id"""
+  findUserById(id: ID!): User
+
+  """Get the current user"""
+  me: User
+
+  """
+  Schedule for a given term. If year is given, returns the most recent schedule generated for that year.
+  """
+  schedule(year: Int): Schedule
+
+  """Get Teaching Preference Survey"""
+  survey: TeachingPreferenceSurvey!
+}
+
+type ResetPasswordMutationResult {
+  """Optional error message"""
+  message: String
+
+  """New user password"""
+  password: String
+
+  """Whether the password was successfully reset"""
+  success: Boolean!
+}
+
+type Response {
+  message: String
+  success: Boolean!
+}
+
+"""User role"""
+enum Role {
+  """Administrator role (department staff etc.)"""
+  ADMIN
+
+  """User role (professor, student etc.)"""
+  USER
+}
+
+"""Generated schedule for a year"""
+type Schedule {
+  """Scheduled courses"""
+  courses(term: Term!): [CourseSection!]
+
+  """When the schedule was generated"""
+  createdAt: Date!
+
+  """ID of the schedule"""
+  id: ID!
+
+  """Year for the schedule"""
+  year: Int!
+}
+
+type TeachingPreferenceSurvey {
+  courses: [CourseID!]!
+}
+
+"""UVic Terms"""
+enum Term {
+  FALL
+  SPRING
+  SUMMER
+}
+
+input UpdateUserInput {
+  """ID of user to update"""
+  id: ID!
+}
+
+type UpdateUserMutationResult {
+  errors: [Error!]
+  user: User
+}
+
+type User {
+  """Determine if the user is marked active"""
+  active: Boolean!
+
+  """Unique User  ID"""
+  id: Int!
+
+  """Password"""
+  password: String!
+
+  """Teaching preferences"""
+  preferences: [CoursePreference!]
+
+  """role - see enum Role"""
+  role: Role!
+
+  """Username"""
+  username: String!
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,8 +1,9 @@
 import { join } from 'path';
 import { makeSchema } from 'nexus';
+import * as types from './types';
 
 export const schema = makeSchema({
-  types: [],
+  types,
   outputs: {
     typegen: join(__dirname, '..', 'node_modules', '@types', 'nexus-typegen', 'index.d.ts'),
     schema: join(__dirname, '..', 'schema.graphql'),

--- a/src/types/Course/ID.ts
+++ b/src/types/Course/ID.ts
@@ -1,0 +1,14 @@
+import { objectType } from 'nexus';
+import { Term } from '../Term';
+
+export const CourseID = objectType({
+  name: 'CourseID',
+  definition(t) {
+    t.nonNull.string('subject', { description: 'Course subject, e.g. SENG, CSC' });
+    t.nonNull.string('code', { description: 'Course code, e.g. 499, 310' });
+    t.nonNull.field('term', {
+      type: Term,
+      description: 'Term course is offered in',
+    });
+  },
+});

--- a/src/types/Course/MeetingTime.ts
+++ b/src/types/Course/MeetingTime.ts
@@ -1,0 +1,21 @@
+import { enumType, objectType } from 'nexus';
+import { Date } from '../Date';
+
+export const Day = enumType({
+  name: 'Day',
+  description: 'Days of the Week',
+  members: ['MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY', 'SUNDAY'],
+});
+
+export const MeetingTime = objectType({
+  name: 'MeetingTime',
+  description: 'Weekday and time of a course section offering',
+  definition(t) {
+    t.nonNull.field('day', {
+      type: Day,
+      description: 'Weekday - see DayEnum',
+    });
+    t.nonNull.field('startTime', { description: 'Start time', type: Date });
+    t.nonNull.field('endTime', { description: 'End time', type: Date });
+  },
+});

--- a/src/types/Course/Preference.ts
+++ b/src/types/Course/Preference.ts
@@ -1,0 +1,29 @@
+import { extendType, objectType } from 'nexus';
+import { CourseID } from './ID';
+
+export const CoursePreference = objectType({
+  name: 'CoursePreference',
+  definition(t) {
+    t.nonNull.field('id', {
+      type: CourseID,
+    });
+    t.nonNull.int('preference');
+  },
+});
+
+export const TeachingPreferenceSurvey = objectType({
+  name: 'TeachingPreferenceSurvey',
+  definition(t) {
+    t.nonNull.list.nonNull.field('courses', { type: CourseID });
+  },
+});
+
+export const PreferenceQuery = extendType({
+  type: 'Query',
+  definition(t) {
+    t.nonNull.field('survey', {
+      type: TeachingPreferenceSurvey,
+      description: 'Get Teaching Preference Survey',
+    });
+  },
+});

--- a/src/types/Course/Section.ts
+++ b/src/types/Course/Section.ts
@@ -1,0 +1,42 @@
+import { arg, extendType, objectType } from 'nexus';
+import { Date } from '../Date';
+import { Term } from '../Term';
+import { User } from '../User';
+import { CourseID } from './ID';
+import { MeetingTime } from './MeetingTime';
+
+export const CourseSection = objectType({
+  name: 'CourseSection',
+  description: 'A set of CourseSections with matching CourseID represent a course offering',
+  definition(t) {
+    t.nonNull.field('CourseID', {
+      type: CourseID,
+      description: 'The course identifier',
+    });
+    t.nonNull.float('hoursPerWeek', { description: 'How many hours per week a course takes' });
+    t.nonNull.int('capacity', { description: 'Maximum capacity of the section' });
+    t.list.nonNull.field('professors', {
+      type: User,
+      description: "Professor's info, if any professors are assigned",
+    });
+    t.nonNull.field('startDate', { description: 'The start date of the course', type: Date });
+    t.nonNull.field('endDate', { description: 'The end date of the course', type: Date });
+    t.nonNull.list.nonNull.field('meetingTimes', {
+      type: MeetingTime,
+      description: 'Days of the week the class is offered in - see Day',
+    });
+  },
+});
+
+export const CourseQuery = extendType({
+  type: 'Query',
+  definition(t) {
+    t.list.nonNull.field('courses', {
+      type: CourseSection,
+      description: 'Get a list of courses for a given term',
+      args: {
+        term: arg({ type: Term }),
+      },
+    });
+  },
+});

--- a/src/types/Course/index.ts
+++ b/src/types/Course/index.ts
@@ -1,0 +1,4 @@
+export * from './ID';
+export * from './MeetingTime';
+export * from './Preference';
+export * from './Section';

--- a/src/types/Date.ts
+++ b/src/types/Date.ts
@@ -1,0 +1,15 @@
+import { scalarType } from 'nexus';
+
+export const Date = scalarType({
+  name: 'Date',
+  asNexusMethod: 'date',
+  serialize() {
+    /* Todo */
+  },
+  parseValue() {
+    /* Todo */
+  },
+  parseLiteral() {
+    /* Todo */
+  },
+});

--- a/src/types/Error.ts
+++ b/src/types/Error.ts
@@ -1,0 +1,9 @@
+import { objectType } from 'nexus';
+
+export const Error = objectType({
+  name: 'Error',
+  definition(t) {
+    t.nonNull.string('message');
+    t.list.nonNull.field('errors', { type: Error });
+  },
+});

--- a/src/types/Response.ts
+++ b/src/types/Response.ts
@@ -1,0 +1,9 @@
+import { objectType } from 'nexus';
+
+export const Response = objectType({
+  name: 'Response',
+  definition(t) {
+    t.nonNull.boolean('success');
+    t.string('message');
+  },
+});

--- a/src/types/Schedule.ts
+++ b/src/types/Schedule.ts
@@ -1,0 +1,56 @@
+import { arg, extendType, inputObjectType, intArg, nonNull, objectType } from 'nexus';
+import { CourseSection } from './Course/Section';
+import { Date } from './Date';
+import { Response } from './Response';
+import { Term } from './Term';
+
+export const GenerateScheduleInput = inputObjectType({
+  name: 'GenerateScheduleInput',
+  definition(t) {
+    t.nonNull.int('year');
+  },
+});
+
+export const Schedule = objectType({
+  name: 'Schedule',
+  description: 'Generated schedule for a year',
+  definition(t) {
+    t.nonNull.id('id', { description: 'ID of the schedule' });
+    t.nonNull.int('year', { description: 'Year for the schedule' });
+    t.nonNull.field('createdAt', { description: 'When the schedule was generated', type: Date });
+    t.list.nonNull.field('courses', {
+      type: CourseSection,
+      description: 'Scheduled courses',
+      args: {
+        term: arg({ type: nonNull(Term) }),
+      },
+    });
+  },
+});
+
+export const ScheduleMutation = extendType({
+  type: 'Mutation',
+  definition(t) {
+    t.nonNull.field('generateSchedule', {
+      type: Response,
+      description: 'Generate schedule',
+      args: {
+        input: arg({ type: nonNull(GenerateScheduleInput) }),
+      },
+    });
+  },
+});
+
+export const ScheduleQuery = extendType({
+  type: 'Query',
+  definition(t) {
+    t.field('schedule', {
+      type: Schedule,
+      description:
+        'Schedule for a given term. If year is given, returns the most recent schedule generated for that year.',
+      args: {
+        year: intArg(),
+      },
+    });
+  },
+});

--- a/src/types/Term.ts
+++ b/src/types/Term.ts
@@ -1,0 +1,7 @@
+import { enumType } from 'nexus';
+
+export const Term = enumType({
+  name: 'Term',
+  description: 'UVic Terms',
+  members: ['FALL', 'SPRING', 'SUMMER'],
+});

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,0 +1,146 @@
+import { arg, enumType, extendType, idArg, inputObjectType, nonNull, objectType, stringArg } from 'nexus';
+import { CoursePreference } from './Course/Preference';
+import { Error } from './Error';
+import { Response } from './Response';
+
+export const AuthPayload = objectType({
+  name: 'AuthPayload',
+  description: 'Returned when a user logs in our logs out.',
+  definition(t) {
+    t.nonNull.boolean('success', { description: 'Whether auth operation was successful or not' });
+    t.nonNull.string('token', { description: 'Auth token used for future requests' });
+    t.string('message', { description: 'Optional error message if success is false' });
+  },
+});
+
+export const ChangeUserPasswordInput = inputObjectType({
+  name: 'ChangeUserPasswordInput',
+  definition(t) {
+    t.nonNull.string('currentPassword');
+    t.nonNull.string('newPassword');
+  },
+});
+
+export const CreateUserMutationResult = objectType({
+  name: 'CreateUserMutationResult',
+  definition(t) {
+    t.nonNull.boolean('success');
+    t.string('message');
+    t.string('username');
+    t.string('password');
+  },
+});
+
+export const ResetPasswordMutationResult = objectType({
+  name: 'ResetPasswordMutationResult',
+  definition(t) {
+    t.nonNull.boolean('success', { description: 'Whether the password was successfully reset' });
+    t.string('message', { description: 'Optional error message' });
+    t.string('password', { description: 'New user password' });
+  },
+});
+
+export const Role = enumType({
+  name: 'Role',
+  description: 'User role',
+  members: [
+    { description: 'Administrator role (department staff etc.)', name: 'ADMIN', value: 'ADMIN' },
+    { description: 'User role (professor, student etc.)', name: 'USER', value: 'USER' },
+  ],
+});
+
+export const UpdateUserInput = inputObjectType({
+  name: 'UpdateUserInput',
+  definition(t) {
+    t.nonNull.id('id', { description: 'ID of user to update' });
+  },
+});
+
+export const UpdateUserMutationResult = objectType({
+  name: 'UpdateUserMutationResult',
+  definition(t) {
+    t.field('user', { type: User });
+    t.list.nonNull.field('errors', { type: Error });
+  },
+});
+
+export const User = objectType({
+  name: 'User',
+  definition(t) {
+    t.nonNull.int('id', { description: 'Unique User  ID' });
+    t.nonNull.string('username', { description: 'Username' });
+    t.nonNull.string('password', { description: 'Password' });
+    t.nonNull.field('role', {
+      type: Role,
+      description: 'role - see enum Role',
+    });
+    t.list.nonNull.field('preferences', {
+      type: CoursePreference,
+      description: 'Teaching preferences',
+    });
+    t.nonNull.boolean('active', { description: 'Determine if the user is marked active' });
+  },
+});
+
+export const UserMutation = extendType({
+  type: 'Mutation',
+  definition(t) {
+    t.nonNull.field('createUser', {
+      type: CreateUserMutationResult,
+      description: 'Register a new user account',
+      args: {
+        username: nonNull(stringArg()),
+      },
+    });
+    t.nonNull.field('login', {
+      type: AuthPayload,
+      description: 'Login into a user account using email and password',
+      args: {
+        username: nonNull(stringArg()),
+        password: nonNull(stringArg()),
+      },
+    });
+    t.nonNull.field('logout', {
+      type: AuthPayload,
+      description: 'Logout the currently logged in user',
+    });
+    t.field('updateUser', {
+      type: UpdateUserMutationResult,
+      description: 'Updates a user given the user id.',
+      args: {
+        input: arg({ type: nonNull(UpdateUserInput) }),
+      },
+    });
+    t.nonNull.field('changeUserPassword', {
+      type: Response,
+      description: 'Change the password of the currently logged in user',
+      args: {
+        input: arg({ type: nonNull(ChangeUserPasswordInput) }),
+      },
+    });
+    t.nonNull.field('resetPassword', {
+      type: ResetPasswordMutationResult,
+      description: 'Reset a users password.',
+      args: {
+        id: nonNull(idArg()),
+      },
+    });
+  },
+});
+
+export const UserQuery = extendType({
+  type: 'Query',
+  definition(t) {
+    t.field('me', {
+      type: User,
+      description: 'Get the current user',
+    });
+    t.field('findUserById', {
+      type: User,
+      description: 'Find a user by their id',
+      args: {
+        id: nonNull(idArg()),
+      },
+    });
+  },
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,7 @@
-// TODO: Create types and export them here which can then be imported in `../schema.ts`
+export * from './User';
+export * from './Schedule';
+export * from './Term';
+export * from './Response';
+export * from './Error';
+export * from './Date';
+export * from './Course';

--- a/test.graphql
+++ b/test.graphql
@@ -1,0 +1,315 @@
+scalar Date
+
+type Query {
+  """
+  Get the current user
+  """
+  me: User
+  """
+  Find a user by their id
+  """
+  findUserById(id: ID!): User
+  """
+  Get Teaching Preference Survey
+  """
+  survey: TeachingPreferenceSurvey!
+  """
+  Get a list of courses for a given term
+  """
+  courses(term: Term): [CourseSection!]
+  """
+  Schedule for a given term. If year is given, returns the most recent schedule generated for that year.
+  """
+  schedule(year: Int): Schedule
+}
+
+"""
+Generated schedule for a year
+"""
+type Schedule {
+  """
+  ID of the schedule
+  """
+  id: ID!
+  """
+  Year for the schedule
+  """
+  year: Int!
+  """
+  When the schedule was generated
+  """
+  createdAt: Date!
+  """
+  Scheduled courses
+  """
+  courses(term: Term!): [CourseSection!]
+}
+
+type Mutation {
+  """
+  Login into a user account using email and password
+  """
+  login(username: String!, password: String!): AuthPayload!
+  """
+  Logout the currently logged in user
+  """
+  logout: AuthPayload!
+  """
+  Register a new user account
+  """
+  createUser(username: String!): CreateUserMutationResult!
+  """
+  Updates a user given the user id.
+  """
+  updateUser(input: UpdateUserInput!): UpdateUserMutationResult
+  """
+  Change the password of the currently logged in user
+  """
+  changeUserPassword(input: ChangeUserPasswordInput!): Response!
+  """
+  Reset a users password.
+  """
+  resetPassword(id: ID!): ResetPasswordMutationResult!
+  """
+  Teaching preferences
+  """
+  createTeachingPreference(input: CreateTeachingPreferenceInput!): Response!
+  """
+  Generate schedule
+  """
+  generateSchedule(input: GenerateScheduleInput!): Response!
+}
+
+type Response {
+  success: Boolean!
+  message: String
+}
+
+type Error {
+  message: String!
+  errors: [Error!]
+}
+
+input ChangeUserPasswordInput {
+  currentPassword: String!
+  newPassword: String!
+}
+
+input CreateTeachingPreferenceInput {
+  peng: Boolean!
+  userId: ID!
+  courses: [CoursePreferenceInput!]!
+}
+
+type TeachingPreferenceSurvey {
+  courses: [CourseID!]!
+}
+
+type CoursePreference {
+  id: CourseID!
+  preference: Int!
+}
+
+input CoursePreferenceInput {
+  """
+  Course subject, e.g. SENG, CSC
+  """
+  subject: String!
+  """
+  Course code, e.g. 499, 310
+  """
+  code: String!
+  """
+  Term course is offered in
+  """
+  term: Term!
+  preference: Int!
+}
+
+input GenerateScheduleInput {
+  year: Int!
+  # TODO: need to fill in the rest of the inputs
+}
+
+type CourseID {
+  """
+  Course subject, e.g. SENG, CSC
+  """
+  subject: String!
+  """
+  Course code, e.g. 499, 310
+  """
+  code: String!
+  """
+  Term course is offered in
+  """
+  term: Term!
+}
+
+type ResetPasswordMutationResult {
+  """
+  Whether the password was successfully reset
+  """
+  success: Boolean!
+  """
+  Optional error message
+  """
+  message: String
+  """
+  New user password
+  """
+  password: String
+}
+
+"""
+A set of CourseSections with matching CourseID represent a course offering
+"""
+type CourseSection {
+  """
+  The course identifier
+  """
+  CourseID: CourseID!
+  """
+  How many hours per week a course takes
+  """
+  hoursPerWeek: Float!
+  """
+  Maximum capacity of the section
+  """
+  capacity: Int!
+  """
+  Professor's info, if any professors are assigned
+  """
+  professors: [User!]
+  """
+  The start date of the course
+  """
+  startDate: Date!
+  """
+  The end date of the course
+  """
+  endDate: Date!
+  """
+  Days of the week the class is offered in - see Day
+  """
+  meetingTimes: [MeetingTime!]!
+}
+
+"""
+Weekday and time of a course section offering
+"""
+type MeetingTime {
+  """
+  Weekday - see DayEnum
+  """
+  day: Day!
+  """
+  Start time
+  """
+  startTime: Date!
+  """
+  End time
+  """
+  endTime: Date!
+}
+
+input UpdateUserInput {
+  """
+  ID of user to update
+  """
+  id: ID!
+}
+
+type UpdateUserMutationResult {
+  user: User
+  errors: [Error!]
+}
+
+type CreateUserMutationResult {
+  success: Boolean!
+  message: String
+  username: String
+  password: String
+}
+
+"""
+Returned when a user logs in our logs out.
+"""
+type AuthPayload {
+  """
+  Whether auth operation was successful or not
+  """
+  success: Boolean!
+  """
+  Auth token used for future requests
+  """
+  token: String!
+  """
+  Optional error message if success is false
+  """
+  message: String
+}
+
+type User {
+  """
+  Unique User  ID
+  """
+  id: Int!
+  """
+  Username
+  """
+  username: String!
+  """
+  Password
+  """
+  password: String!
+  """
+  role - see enum Role
+  """
+  role: Role!
+  """
+  Teaching preferences
+  """
+  preferences: [CoursePreference!]
+  """
+  Determine if the user is marked active
+  """
+  active: Boolean!
+}
+
+"""
+Days of the Week
+"""
+enum Day {
+  MONDAY
+  TUESDAY
+  WEDNESDAY
+  THURSDAY
+  FRIDAY
+  SATURDAY
+  SUNDAY
+}
+
+"""
+User role
+"""
+enum Role {
+  """
+  Administrator role (department staff etc.)
+  """
+  ADMIN
+  """
+  User role (professor, student etc.)
+  """
+  USER
+}
+
+"""
+UVic Terms
+"""
+enum Term {
+  FALL
+  SPRING
+  SUMMER
+}
+


### PR DESCRIPTION
Initialized all the schema types in specific folders for everything we need. Nexus has an SDL converter (https://nexusjs.org/converter) so I just copy and pasted the schema we made with company 3 into there. I split everything up into respective files just for organization, but otherwise it was all automated.

`./schema.graphql` should now match `./test.graphql` (schema is auto-generated by nexus and test is what we made with company 3).