### PR TITLE
Feat/actual user crud mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@
 Back end code repository for SENG499 Summer 2022 project.
 
 ## Develop
+
 To run the backend locally you need to run a Postgres database and the GraphQL server separately. After cloning the repo, follow these steps to get things up and running:
+
 1. Run `npm ci` to install the project's dependencies
-1. Run `docker-compose up` to boot up a Docker container running the Postgres database
-2. Run `./setup.sh` to start the GraphQL server at [`http://localhost:4000/`](localhost:4000). This script does the following:
+2. Run `docker-compose up` to boot up a Docker container running the Postgres database
+3. Run `./setup.sh` to start the GraphQL server at [`http://localhost:4000/`](localhost:4000). This script does the following:
    - Runs necessary database migrations
    - Seeds the database with dummy data for testing
    - Runs the server (automatically reloads with changes to codebase)

--- a/schema.graphql
+++ b/schema.graphql
@@ -209,9 +209,6 @@ input UpdateUserInput {
   """New active status of user"""
   active: Boolean
 
-  """ID of user to update"""
-  id: ID!
-
   """New name of user"""
   name: String
 

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,0 +1,10 @@
+import { hash } from 'bcrypt';
+
+const generateHashPassword = (password: string) => {
+  if (password.length < 8) {
+    throw new Error('Password must be at least 8 characters long');
+  }
+  return hash(password, 10);
+};
+
+export default generateHashPassword;


### PR DESCRIPTION
Closes #24 

Implements CRUD user mutations:
- `createUser`
  - Takes in name, username, password, and role for user and creates a new entity in database (with hashed pwd ;) )
- `updateUser`
  - Takes in username for user, and optional name, role, and active to be updated for that user
- `changeUserPassword`
  - Takes in username, currentPassword, and newPasssword; if currentPassword matches existing password for user, it gets updated in db with newPassword (again, hashed)

## Important Observation

Does **_not_** implement `resetPassword` mutation for sole reason of how?? if there's no way of contacting them to make sure they're them