### PR TITLE
Feat/actual user crud mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@
 Back end code repository for SENG499 Summer 2022 project.
 
 ## Develop
+
 To run the backend locally you need to run a Postgres database and the GraphQL server separately. After cloning the repo, follow these steps to get things up and running:
+
 1. Run `npm ci` to install the project's dependencies
-1. Run `docker-compose up` to boot up a Docker container running the Postgres database
-2. Run `./setup.sh` to start the GraphQL server at [`http://localhost:4000/`](localhost:4000). This script does the following:
+2. Run `docker-compose up` to boot up a Docker container running the Postgres database
+3. Run `./setup.sh` to start the GraphQL server at [`http://localhost:4000/`](localhost:4000). This script does the following:
    - Runs necessary database migrations
    - Seeds the database with dummy data for testing
    - Runs the server (automatically reloads with changes to codebase)

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,17 +1,15 @@
 import { PrismaClient, Term, Peng, Role } from '@prisma/client';
-import generateHashPassword from '../src/utils/hash';
 import courseData from './course_migration.json';
 import userData from './user_seed.json';
 const prisma = new PrismaClient();
 
 async function main() {
-  const hashedPwd = await generateHashPassword('123456789');
   for (const userObj of userData) {
     await (prisma as PrismaClient).user.create({
       data: {
         name: userObj.name,
         username: userObj.username,
-        password: hashedPwd,
+        password: '$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS',
         role: userObj.role as Role,
       },
     });

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,15 +1,17 @@
 import { PrismaClient, Term, Peng, Role } from '@prisma/client';
+import generateHashPassword from '../src/utils/hash';
 import courseData from './course_migration.json';
 import userData from './user_seed.json';
 const prisma = new PrismaClient();
 
 async function main() {
+  const hashedPwd = await generateHashPassword('123456789');
   for (const userObj of userData) {
     await (prisma as PrismaClient).user.create({
       data: {
         name: userObj.name,
         username: userObj.username,
-        password: userObj.password,
+        password: hashedPwd,
         role: userObj.role as Role,
       },
     });

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -9,7 +9,7 @@ async function main() {
       data: {
         name: userObj.name,
         username: userObj.username,
-        password: '$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS',
+        password: userObj.password,
         role: userObj.role as Role,
       },
     });

--- a/prisma/user_seed.json
+++ b/prisma/user_seed.json
@@ -2,919 +2,919 @@
   {
     "name": "Daniel Hoffman",
     "username": "dhoffman",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "LillAnne Jackson",
     "username": "engradu",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Jason Corless",
     "username": "jcorless",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Venkatesh Srinivasan",
     "username": "srinivas",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Micaela Serra",
     "username": "mserra",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Wendy Myrvold",
     "username": "wendym",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Michael Zastre",
     "username": "zastre",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Daniel German",
     "username": "dmg",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Michael McGuire",
     "username": "mmcguire",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Brock MacLeod",
     "username": "brock1",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Suzan Last",
     "username": "sulast",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Tara Coulter",
     "username": "taracoul",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Brad Buckham",
     "username": "bbuckham",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Ben Nadler",
     "username": "bnadler",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Robert Steacy",
     "username": "rsteacy",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Svetlana Oshkai",
     "username": "soshkai",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Heath Emerson",
     "username": "hemerson",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Michael Francis",
     "username": "mikey.davey.francis",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Jing Huang",
     "username": "huangj",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Joost Massolt",
     "username": "jmassolt",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Mark Laidlaw",
     "username": "laidlaw",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Melanie Tory",
     "username": "mtory",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Daniela Damian",
     "username": "danielad",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Jens Weber",
     "username": "jens",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Kin Fun Li",
     "username": "kinli",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Paul van Dam-Bates",
     "username": "paul.vandambates",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Jen Lindquist",
     "username": "jflindquist",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Coreen Hamilton",
     "username": "coreenh",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Gautam Srivastava",
     "username": "srivastavag",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Brittany Halverson-Duncan",
     "username": "bghalver",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Peter Williamson",
     "username": "pwilliam",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Jane Wodlinger",
     "username": "jw",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Celina Berg",
     "username": "celinag",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Issa Traore",
     "username": "itraore",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Mihai Sima",
     "username": "msima",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Adam Zielinski",
     "username": "adam",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Sandy Briggs",
     "username": "briggsag",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Neil Burford",
     "username": "nburford",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Hausi Muller",
     "username": "hausi",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Rich Little",
     "username": "rlittle",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "ADMIN"
   },
   {
     "name": "Ulrike Stege",
     "username": "ustege",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Sudhakar Ganti",
     "username": "sganti",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Valerie King",
     "username": "val",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Jianping Pan",
     "username": "pan",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Peter Wild",
     "username": "pwild",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Susan Fiddler",
     "username": "sfiddler",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Boualem Khouider",
     "username": "khouider",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Adriana Wise",
     "username": "awise",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Michelle Edwards",
     "username": "edwardsm",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Minghua Lin",
     "username": "linm",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Florin Diacu",
     "username": "diaflorin",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Gary MacGillivray",
     "username": "gmacgill",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Richard Keeler",
     "username": "rkeeler",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Nigel Horspool",
     "username": "nigelh",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Mary Lesperance",
     "username": "mlespera",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Fan Wu",
     "username": "fwu",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Sue Whitesides",
     "username": "sue",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Bruce Kapron",
     "username": "bmkapron",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Kui Wu",
     "username": "wkui",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Michael Simpson",
     "username": "michaelesimp",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Mantis Cheng",
     "username": "mantis.cheng",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Ash Senini",
     "username": "asenini",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Jane Butterfield",
     "username": "jvbutter",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Robin Koytcheff",
     "username": "rmjk",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Christopher Duffy",
     "username": "CHRISTOPHER.DUFFY",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "David Collins",
     "username": "vegoilbenz",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Yvonne Coady",
     "username": "ycoady",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Min Tsao",
     "username": "mtsao",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Chedomir Barone",
     "username": "baronec",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Bill Bird",
     "username": "bbird",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Christopher Willmore",
     "username": "willmore",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Laura Teshima",
     "username": "lteshima",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Jonathan Rudge",
     "username": "jrudge",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Haytham El Miligi",
     "username": "haytham",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Xiaodai Dong",
     "username": "xdong",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Rhonda Korol",
     "username": "rkorol",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Margaret-Anne Storey",
     "username": "mstorey",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Tibor van Rooij",
     "username": "vanrooij",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Frank Ruskey",
     "username": "ruskey",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Caleb Shortt",
     "username": "cshortt",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Travis Martin",
     "username": "travismartin",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "David Johnson",
     "username": "davidjo",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Harry Kwok",
     "username": "hlkwok",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Michael Miller",
     "username": "mmiller",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Alex Thomo",
     "username": "thomo",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Leo Spalteholz",
     "username": "leos",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Christopher Eagle",
     "username": "eaglec",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Anthony Cecil",
     "username": "anthony",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Asad Asaduzzaman",
     "username": "sasaduzz",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Amanda Malloch",
     "username": "anjam",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Josh Manzer",
     "username": "jmanzer",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "George Tzanetakis",
     "username": "gtzan",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Farouk Nathoo",
     "username": "nathoo",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Harmen Zijlstra",
     "username": "harmenszijlstra",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Helen Bailey",
     "username": "hlbailey",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Muhammad Awais",
     "username": "mawais",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Anthony Quas",
     "username": "aquas",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Eirini Kalliamvakou",
     "username": "irina",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Ilamparithi Thirumarai Chelvan",
     "username": "ilampari",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Cornelia Bohne",
     "username": "bohne",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Tianming Wei",
     "username": "twei",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Eric Cormier",
     "username": "ecormier",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Ali Mashreghi",
     "username": "ali.mashreghi87",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Charlie Zhang",
     "username": "clzhang316",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Fayez Gebali",
     "username": "fayez",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Panajotis Agathoklis",
     "username": "panagath",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Amirali Baniasadi",
     "username": "amiralib",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Yue Li",
     "username": "liyue331",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Andrew McEachern",
     "username": "amceachern",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Keivan Hassani Monfared",
     "username": "k1monfared",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Yanxia Deng",
     "username": "yanxiadeng",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Joanna Niezen",
     "username": "joanna.niezen",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Chris Bruce",
     "username": "cmbruce",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Adam Murray",
     "username": "adammurray",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Zahra Nikdel",
     "username": "nikdel",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Neil Ernst",
     "username": "nernst",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Adeshina Alani",
     "username": "aalani",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Xuekui Zhang",
     "username": "xuekui",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Scott McIndoe",
     "username": "mcindoe",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Anthony Estey",
     "username": "aestey",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Hosna Jabbari",
     "username": "jabbari",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Yakine Bahri",
     "username": "ybahri",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Tom Thompson",
     "username": "wthompso",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Dayton Preissl",
     "username": "dpreissl",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Charles Perin",
     "username": "cperin",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Chi Kou",
     "username": "cmrkou",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Sana Shuja",
     "username": "sanashuja",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Navneet Popli",
     "username": "npopli",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Monika Smith",
     "username": "monikasm",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Kate Skipsey",
     "username": "kskipsey",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Robert Nishida",
     "username": "rnishida",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Natasha Morrison",
     "username": "nmorrison",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Babak Manouchehrinia",
     "username": "bmn14",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Nishant Mehta",
     "username": "nmehta",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Ahmad Abdullah",
     "username": "abdullah",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Michael Adams",
     "username": "frodo",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Daler Rakhmatov",
     "username": "daler",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Hong-Chuan Yang",
     "username": "hy",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Flavio Firmani",
     "username": "ffirmani",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Sowmya Somanath",
     "username": "sowmyasomanath",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Joe Krysl",
     "username": "jkrysl",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Sean Chester",
     "username": "schester",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Raja Ali Riaz",
     "username": "rajaaliriaz",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Sushil Saini",
     "username": "jssaini",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Torsten Schoeneberg",
     "username": "torstenschoeneberg",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Majid Mazrooei",
     "username": "majidmazrooei",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Nahid Pourdolat Safari",
     "username": "nahidp",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Joseph Horan",
     "username": "jahoran",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Bob Kowalewski",
     "username": "kowalews",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Michele de Souza",
     "username": "michelesouzaca",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Quinton Yong",
     "username": "quintillion.y",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Charlie Bull",
     "username": "clbull",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   },
   {
     "name": "Saeedeh Saghlatoun",
     "username": "ssaghlatoun",
-    "password": "asdf123",
+    "password": "$2b$10$tDsA4Ts.DSi4Ry9DoxxQHOS.5ethLRqEFsCO9shyPDefKNaQYXahS",
     "role": "USER"
   }
 ]

--- a/schema.graphql
+++ b/schema.graphql
@@ -231,6 +231,9 @@ type User {
   """Determine if the user is marked active"""
   active: Boolean!
 
+  """User id"""
+  id: Int!
+
   """Name of the user"""
   name: String
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -16,6 +16,9 @@ type AuthPayload {
 
 input ChangeUserPasswordInput {
   currentPassword: String!
+
+  """ID of user to change password for"""
+  id: Int!
   newPassword: String!
 }
 
@@ -64,6 +67,13 @@ type CourseSection {
   startDate: Date!
 }
 
+input CreateUserInput {
+  name: String
+  password: String!
+  role: Role!
+  username: String!
+}
+
 type CreateUserMutationResult {
   message: String
   password: String
@@ -110,17 +120,7 @@ type Mutation {
   changeUserPassword(input: ChangeUserPasswordInput!): Response!
 
   """Register a new user account"""
-  createUser(
-    """Name of the user"""
-    name: String
-
-    """Password for user"""
-    password: String!
-    role: Role!
-
-    """Username for user"""
-    username: String!
-  ): CreateUserMutationResult!
+  createUser(input: CreateUserInput!): CreateUserMutationResult!
 
   """Generate schedule"""
   generateSchedule(input: GenerateScheduleInput!): Response!
@@ -212,14 +212,14 @@ input UpdateUserInput {
   """New active status of user"""
   active: Boolean
 
+  """User id to be changed"""
+  id: Int!
+
   """New name of user"""
   name: String
 
   """New role of user"""
   role: Role
-
-  """New username of user"""
-  username: String
 }
 
 type UpdateUserMutationResult {
@@ -231,8 +231,8 @@ type User {
   """Determine if the user is marked active"""
   active: Boolean!
 
-  """Unique User  ID"""
-  id: Int!
+  """Name of the user"""
+  name: String
 
   """Password"""
   password: String!

--- a/schema.graphql
+++ b/schema.graphql
@@ -209,9 +209,6 @@ input UpdateUserInput {
   """New active status of user"""
   active: Boolean
 
-  """ID of user to update"""
-  id: ID!
-
   """New name of user"""
   name: String
 

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -19,7 +19,7 @@ export const AuthPayload = objectType({
 export const ChangeUserPasswordInput = inputObjectType({
   name: 'ChangeUserPasswordInput',
   definition(t) {
-    t.nonNull.string('username', { description: 'Username of user to change password for' });
+    t.nonNull.int('id', { description: 'ID of user to change password for' });
     t.nonNull.string('currentPassword');
     t.nonNull.string('newPassword');
   },
@@ -56,7 +56,7 @@ export const Role = enumType({
 export const UpdateUserInput = inputObjectType({
   name: 'UpdateUserInput',
   definition(t) {
-    t.string('username', { description: 'New username of user' });
+    t.nonNull.int('id', { description: 'User id to be changed' });
     t.string('name', { description: 'New name of user' });
     t.field('role', { type: Role, description: 'New role of user' });
     t.boolean('active', { description: 'New active status of user' });
@@ -174,11 +174,10 @@ export const UserMutation = extendType({
         input: arg({ type: nonNull(UpdateUserInput) }),
       },
       resolve: async (_, args, { prisma }) => {
-        const { username, name, role, active } = args.input;
+        const { id, name, role, active } = args.input;
         const user = await prisma.user.update({
-          where: { username: username ?? undefined },
+          where: { id },
           data: {
-            username: username ?? undefined,
             name,
             role: role ?? undefined,
             active: active ?? undefined,
@@ -195,10 +194,10 @@ export const UserMutation = extendType({
         input: arg({ type: nonNull(ChangeUserPasswordInput) }),
       },
       resolve: async (_, args, { prisma }) => {
-        const { username, currentPassword, newPassword } = args.input;
+        const { id, currentPassword, newPassword } = args.input;
 
         const user = await (prisma as PrismaClient).user.findUnique({
-          where: { username },
+          where: { id },
         });
 
         if (!user) return { success: false, message: 'User not found' };
@@ -211,7 +210,7 @@ export const UserMutation = extendType({
 
         await (prisma as PrismaClient).user.update({
           where: {
-            username,
+            id,
           },
           data: {
             password: hashPwd,

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -127,7 +127,7 @@ export const UserMutation = extendType({
         });
 
         if (!newUser) return { success: false, message: 'Could not create user' };
-        else return { success: true, message: 'User created' };
+        return { success: true, message: 'User created' };
       },
     });
     t.nonNull.field('login', {
@@ -180,8 +180,8 @@ export const UserMutation = extendType({
           },
         });
 
-        if (user) return { user };
-        else return { errors: [{ message: 'Could not update user' }] };
+        if (!user) return { errors: [{ message: 'Could not update user' }] };
+        return { user };
       },
     });
     t.nonNull.field('changeUserPassword', {
@@ -198,7 +198,7 @@ export const UserMutation = extendType({
         if (!user) return { success: false, message: 'User not found' };
 
         const isValid = await compare(currentPassword, user.password);
-        if (!isValid) throw new Error('Invalid password');
+        if (!isValid) return { success: false, message: 'Invalid current password' };
 
         await (prisma as PrismaClient).user.update({
           where: {

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,0 +1,10 @@
+import { hash } from 'bcrypt';
+
+const generateHashPassword = (password: string) => {
+  if (password.length < 8) {
+    throw new Error('Password must be at least 8 characters long');
+  }
+  return hash(password, 10);
+};
+
+export default generateHashPassword;


### PR DESCRIPTION
Closes #24 

Implements CRUD user mutations:
- `createUser`
  - Takes in name, username, password, and role for user and creates a new entity in database (with hashed pwd ;) )
- `updateUser`
  - Takes in username for user, and optional name, role, and active to be updated for that user
- `changeUserPassword`
  - Takes in username, currentPassword, and newPasssword; if currentPassword matches existing password for user, it gets updated in db with newPassword (again, hashed)

## Important Observation

Does **_not_** implement `resetPassword` mutation for sole reason of how?? if there's no way of contacting them to make sure they're them