### PR TITLE
Add docker image build and publishing to CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,13 +2,14 @@ name: Lint and build repo
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
   push:
     branches: [main]
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  REPO_NAME: ${{ github.repository }}
+  IS_PUSH_ON_DEFAULT: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
 jobs:
   run-lint:
@@ -53,12 +54,39 @@ jobs:
         id: meta
         uses: docker/metadata-action@v2
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}
 
+      - name: Create alternate default branch tag
+        id: defaultbranchtag
+        if: ${{ env.IS_PUSH_ON_DEFAULT }}
+        run: |
+          DEFAULT_TAG=${{ env.REGISTRY }}/${{ env.REPO_NAME }}:latest
+          # change all to lowercase
+          DEFAULT_TAG=$(echo $DEFAULT_TAG | tr '[A-Z]' '[a-z]')
+          echo "::set-output name=defaulttag::${DEFAULT_TAG}"
+      
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: ${{ github.event_name == 'push' }}
-          tags: ${{ steps.meta.outputs.tags }}-${{ github.run_number }}
-          labels: ${{ steps.meta.outputs.labels }}
+          push: ${{ env.IS_PUSH_ON_DEFAULT }}
+          tags: |
+            ${{ steps.meta.outputs.tags }}-${{ github.run_id }}
+            ${{ steps.defaultbranchtag.outputs.defaulttag }}
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            runnumber=${{ github.run_id }}
+  
+  run-integration-tests:
+    runs-on: ubuntu-latest
+    needs: build-docker-image
+    steps:
+      - name: Dispatch event to trigger integration tests
+        uses: peter-evans/repository-dispatch@v2
+        if: ${{ env.IS_PUSH_ON_LATEST }}
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: seng499-s22-company3/shared
+          event-type: backend
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "repo": "backend"}' 
+        

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,6 +55,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+      - name: print event name
+        run: echo ${{ github.event_name }}
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Create alternate default branch tag
         id: defaultbranchtag
-        if: ${{ env.IS_PUSH_ON_DEFAULT }}
+        if: ${{ env.IS_PUSH_ON_DEFAULT  == 'true' }}
         run: |
           DEFAULT_TAG=${{ env.REGISTRY }}/${{ env.REPO_NAME }}:latest
           # change all to lowercase
@@ -83,10 +83,8 @@ jobs:
     steps:
       - name: Dispatch event to trigger integration tests
         uses: peter-evans/repository-dispatch@v2
-        if: ${{ env.IS_PUSH_ON_LATEST }}
+        if: ${{ env.IS_PUSH_ON_DEFAULT == 'true' }}
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: seng499-s22-company3/shared
-          event-type: backend
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "repo": "backend"}' 
         

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -87,4 +87,6 @@ jobs:
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: seng499-s22-company3/shared
+          event-type: company4-backend
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "repo": "company4-backend"}' 
         

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ main ]
   push:
-    branches: [publish-docker-image]
+    branches: [main]
 
 env:
   REGISTRY: ghcr.io
@@ -54,9 +54,6 @@ jobs:
         uses: docker/metadata-action@v2
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: print event name
-        run: echo ${{ github.event_name }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,6 +3,14 @@ name: Lint Code Base
 on:
   pull_request:
     branches: [ main ]
+  push:
+    branches: 
+      - publish-docker-image
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   run-lint:
     runs-on: ubuntu-latest
@@ -17,6 +25,27 @@ jobs:
         
       - name: Run ESLint
         run: npm run lint
+
+      - name: Log in to the container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v2
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}-${{ github.run_number }}
+          labels: ${{ steps.meta.outputs.labels }}
 
       # TODO: Run tests when they are available
       #- name: Run Tests

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,11 +1,10 @@
-name: Lint Code Base
+name: Lint and build repo
 
 on:
   pull_request:
     branches: [ main ]
   push:
-    branches: 
-      - publish-docker-image
+    branches: [publish-docker-image]
 
 env:
   REGISTRY: ghcr.io
@@ -20,11 +19,28 @@ jobs:
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
+
       - name: Install Dependencies
         run: npm install
-        
+
       - name: Run ESLint
         run: npm run lint
+
+      # TODO: Run tests when they are available
+      #- name: Run Tests
+      #  run: npm run test
+
+  build-docker-image:
+    runs-on: ubuntu-latest
+    needs: run-lint
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Log in to the container registry
         uses: docker/login-action@v2
@@ -43,10 +59,6 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: true
+          push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}-${{ github.run_number }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      # TODO: Run tests when they are available
-      #- name: Run Tests
-      #  run: npm run test


### PR DESCRIPTION
This PR adds a job to the CI workflow for building and publishing the Apollo server docker image. The workflow will always **build the image** in case of PRs and direct pushes to main **but will only publish the image** to GitHub Packages in case of a push to main (which should always be after a PR is merged). 

**DOCKER IMAGE NAME AND VERSIONING**
The image will be published to [here](https://github.com/SENG499-Company-4/Backend/pkgs/container/backend) and will have coordinates of this format: `ghcr.io/seng499-company-4/backend:main-run_id`, where `run_id` is just a unique number provided by GitHub for workflow each run in the repository (see image below, taken from [here](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)).

![image](https://user-images.githubusercontent.com/24327291/177432539-c36cca19-9978-4422-a3d7-04e6f660100d.png)

The latest images produced by the main branch will also have a secondary tag of the form: `ghcr.io/seng-499-company-4/backend:latest`. This is to allow the shared integration tests to easily pull down the latest image and test with it. **Only the latest docker image will have this tag**.

If this is not the versioning scheme desired by the team, we can discuss alternatives such as using semantic versioning or only having a "latest" image that corresponds the latest and greatest on main. Please let me know on the PR if this is something you would like.

**UPDATE**: This comment has been edited to reflect the changes from combining changes from Ben's PR (#50)