### PR TITLE
Fix/gen schedule mutation

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -119,7 +119,7 @@ type Error {
 input GenerateScheduleInput {
   algorithm1: Company!
   algorithm2: Company!
-  courses: [CourseInput]
+  courses: [CourseInput!]
   term: Term!
   year: Int!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -40,14 +40,11 @@ input CourseIDInput {
   """Course code, e.g. 499, 310"""
   code: String!
 
+  """Number of sections in the course"""
+  sections: Int!
+
   """Course subject, e.g. SENG, CSC"""
   subject: String!
-
-  """Term course is offered in"""
-  term: Term!
-
-  """Year course is offered in"""
-  year: Int!
 }
 
 type CoursePreference {

--- a/schema.graphql
+++ b/schema.graphql
@@ -36,6 +36,20 @@ type CourseID {
   year: Int!
 }
 
+input CourseIDInput {
+  """Course code, e.g. 499, 310"""
+  code: String!
+
+  """Course subject, e.g. SENG, CSC"""
+  subject: String!
+
+  """Term course is offered in"""
+  term: Term!
+
+  """Year course is offered in"""
+  year: Int!
+}
+
 type CoursePreference {
   id: CourseID!
   preference: Int!
@@ -100,6 +114,8 @@ type Error {
 }
 
 input GenerateScheduleInput {
+  courses: [CourseIDInput]
+  term: Term!
   year: Int!
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -42,12 +42,12 @@ type CourseID {
   year: Int!
 }
 
-input CourseIDInput {
+input CourseInput {
   """Course code, e.g. 499, 310"""
   code: String!
 
   """Number of sections in the course"""
-  sections: Int!
+  section: Int!
 
   """Course subject, e.g. SENG, CSC"""
   subject: String!
@@ -119,7 +119,7 @@ type Error {
 input GenerateScheduleInput {
   algorithm1: Company!
   algorithm2: Company!
-  courses: [CourseIDInput]
+  courses: [CourseInput]
   term: Term!
   year: Int!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -22,6 +22,12 @@ input ChangeUserPasswordInput {
   newPassword: String!
 }
 
+"""Company 3 and 4"""
+enum Company {
+  COMPANY3
+  COMPANY4
+}
+
 type CourseID {
   """Course code, e.g. 499, 310"""
   code: String!
@@ -111,6 +117,8 @@ type Error {
 }
 
 input GenerateScheduleInput {
+  algorithm1: Company!
+  algorithm2: Company!
   courses: [CourseIDInput]
   term: Term!
   year: Int!

--- a/src/types/Company.ts
+++ b/src/types/Company.ts
@@ -1,0 +1,7 @@
+import { enumType } from 'nexus';
+
+export const Company = enumType({
+  name: 'Company',
+  description: 'Company 3 and 4',
+  members: ['COMPANY3', 'COMPANY4'],
+});

--- a/src/types/Course/ID.ts
+++ b/src/types/Course/ID.ts
@@ -1,8 +1,21 @@
-import { objectType } from 'nexus';
+import { inputObjectType, objectType } from 'nexus';
 import { Term } from '../Term';
 
 export const CourseID = objectType({
   name: 'CourseID',
+  definition(t) {
+    t.nonNull.string('subject', { description: 'Course subject, e.g. SENG, CSC' });
+    t.nonNull.string('code', { description: 'Course code, e.g. 499, 310' });
+    t.nonNull.field('term', {
+      type: Term,
+      description: 'Term course is offered in',
+    });
+    t.nonNull.int('year', { description: 'Year course is offered in' });
+  },
+});
+
+export const CourseIDInput = inputObjectType({
+  name: 'CourseIDInput',
   definition(t) {
     t.nonNull.string('subject', { description: 'Course subject, e.g. SENG, CSC' });
     t.nonNull.string('code', { description: 'Course code, e.g. 499, 310' });

--- a/src/types/Course/ID.ts
+++ b/src/types/Course/ID.ts
@@ -14,11 +14,11 @@ export const CourseID = objectType({
   },
 });
 
-export const CourseIDInput = inputObjectType({
-  name: 'CourseIDInput',
+export const CourseInput = inputObjectType({
+  name: 'CourseInput',
   definition(t) {
     t.nonNull.string('subject', { description: 'Course subject, e.g. SENG, CSC' });
     t.nonNull.string('code', { description: 'Course code, e.g. 499, 310' });
-    t.nonNull.int('sections', { description: 'Number of sections in the course' });
+    t.nonNull.int('section', { description: 'Number of sections in the course' });
   },
 });

--- a/src/types/Course/ID.ts
+++ b/src/types/Course/ID.ts
@@ -19,10 +19,6 @@ export const CourseIDInput = inputObjectType({
   definition(t) {
     t.nonNull.string('subject', { description: 'Course subject, e.g. SENG, CSC' });
     t.nonNull.string('code', { description: 'Course code, e.g. 499, 310' });
-    t.nonNull.field('term', {
-      type: Term,
-      description: 'Term course is offered in',
-    });
-    t.nonNull.int('year', { description: 'Year course is offered in' });
+    t.nonNull.int('sections', { description: 'Number of sections in the course' });
   },
 });

--- a/src/types/Course/Preference.ts
+++ b/src/types/Course/Preference.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Term } from '@prisma/client';
 import { extendType, objectType } from 'nexus';
 import { getUserId } from '../../utils/auth';
 import { CourseID } from './ID';
@@ -35,11 +35,34 @@ export const PreferenceQuery = extendType({
           },
         });
 
-        const courses = prefs.map(({ courseID, rank }) => ({
-          id: courseID,
-          preference: rank,
-        }));
+        const courses = prefs.map(async ({ courseID, rank }) => {
+          const courseData = await (prisma as PrismaClient).course.findUnique({
+            where: {
+              id: courseID,
+            },
+          });
 
+          if (!courseData) {
+            return {
+              id: {
+                subject: '',
+                code: '',
+                term: '' as Term,
+                year: 0,
+              },
+              preference: 0,
+            };
+          }
+          return {
+            id: {
+              subject: courseData.subject,
+              code: courseData.code,
+              term: courseData.term,
+              year: courseData.year,
+            },
+            preference: rank ?? 0,
+          };
+        });
         return {
           courses,
         };

--- a/src/types/Course/Preference.ts
+++ b/src/types/Course/Preference.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, Term } from '@prisma/client';
+import { PrismaClient } from '@prisma/client';
 import { extendType, objectType } from 'nexus';
 import { getUserId } from '../../utils/auth';
 import { CourseID } from './ID';
@@ -35,35 +35,10 @@ export const PreferenceQuery = extendType({
           },
         });
 
-        const courses = prefs.map(async ({ courseID, rank }) => {
-          const courseData = await (prisma as PrismaClient).course.findUnique({
-            where: {
-              id: courseID,
-            },
-          });
-
-          if (!courseData) {
-            return {
-              id: {
-                subject: '',
-                code: '',
-                term: '' as Term,
-                year: 0,
-              },
-              preference: 0,
-            };
-          }
-
-          return {
-            id: {
-              subject: courseData.subject,
-              code: courseData.code,
-              term: courseData.term,
-              year: courseData.year,
-            },
-            preference: rank ?? 0,
-          };
-        });
+        const courses = prefs.map(({ courseID, rank }) => ({
+          id: courseID,
+          preference: rank,
+        }));
 
         return {
           courses,

--- a/src/types/Schedule.ts
+++ b/src/types/Schedule.ts
@@ -2,7 +2,7 @@ import { PrismaClient } from '@prisma/client';
 import { arg, extendType, inputObjectType, intArg, nonNull, objectType } from 'nexus';
 import fetch from 'node-fetch';
 import { Company } from './Company';
-import { CourseIDInput } from './Course';
+import { CourseInput } from './Course';
 import { CourseSection } from './Course/Section';
 import { Date } from './Date';
 import { Response } from './Response';
@@ -13,7 +13,7 @@ export const GenerateScheduleInput = inputObjectType({
   definition(t) {
     t.nonNull.int('year');
     t.nonNull.field('term', { type: Term });
-    t.list.field('courses', { type: CourseIDInput });
+    t.list.field('courses', { type: CourseInput });
     t.nonNull.field('algorithm1', { type: Company });
     t.nonNull.field('algorithm2', { type: Company });
   },

--- a/src/types/Schedule.ts
+++ b/src/types/Schedule.ts
@@ -1,5 +1,6 @@
 import { arg, extendType, inputObjectType, intArg, nonNull, objectType } from 'nexus';
 import fetch from 'node-fetch';
+import { Company } from './Company';
 import { CourseIDInput } from './Course';
 import { CourseSection } from './Course/Section';
 import { Date } from './Date';
@@ -12,6 +13,8 @@ export const GenerateScheduleInput = inputObjectType({
     t.nonNull.int('year');
     t.nonNull.field('term', { type: Term });
     t.list.field('courses', { type: CourseIDInput });
+    t.nonNull.field('algorithm1', { type: Company });
+    t.nonNull.field('algorithm2', { type: Company });
   },
 });
 

--- a/src/types/Schedule.ts
+++ b/src/types/Schedule.ts
@@ -12,7 +12,7 @@ export const GenerateScheduleInput = inputObjectType({
   definition(t) {
     t.nonNull.int('year');
     t.nonNull.field('term', { type: Term });
-    t.list.field('courses', { type: CourseInput });
+    t.list.field('courses', { type: nonNull(CourseInput) });
     t.nonNull.field('algorithm1', { type: Company });
     t.nonNull.field('algorithm2', { type: Company });
   },

--- a/src/types/Schedule.ts
+++ b/src/types/Schedule.ts
@@ -1,4 +1,3 @@
-import { PrismaClient } from '@prisma/client';
 import { arg, extendType, inputObjectType, intArg, nonNull, objectType } from 'nexus';
 import fetch from 'node-fetch';
 import { Company } from './Company';
@@ -45,51 +44,51 @@ export const ScheduleMutation = extendType({
       args: {
         input: arg({ type: nonNull(GenerateScheduleInput) }),
       },
-      resolve: async (_, { input: { algorithm1, term } }, { prisma }) => {
+      resolve: async (_, { input: { algorithm1 } }) => {
         // TODO: Replace second url with correct one for company 3 algorithm 1
         const url =
           algorithm1 === 'COMPANY4'
             ? 'https://seng499company4algorithm1.herokuapp.com/generate_schedule'
             : "'https://seng499company4algorithm1.herokuapp.com/generate_schedule'";
 
-        const fallCourses =
-          term === 'FALL'
-            ? (prisma as PrismaClient).course.findMany({
-                where: {
-                  term: 'FALL',
-                },
-              })
-            : [];
+        // const fallCourses =
+        //   term === 'FALL'
+        //     ? (prisma as PrismaClient).course.findMany({
+        //         where: {
+        //           term: 'FALL',
+        //         },
+        //       })
+        //     : [];
 
-        const springCourses =
-          term === 'SPRING'
-            ? (prisma as PrismaClient).course.findMany({
-                where: {
-                  term: 'SPRING',
-                },
-              })
-            : [];
+        // const springCourses =
+        //   term === 'SPRING'
+        //     ? (prisma as PrismaClient).course.findMany({
+        //         where: {
+        //           term: 'SPRING',
+        //         },
+        //       })
+        //     : [];
 
-        const summerCourses =
-          term === 'SUMMER'
-            ? (
-                await (prisma as PrismaClient).course.findMany({
-                  where: {
-                    term: 'SUMMER',
-                  },
-                })
-              ).map((course) => {
-                const meetingTime = (prisma as PrismaClient).meetingTime.findMany({});
+        // const summerCourses =
+        //   term === 'SUMMER'
+        //     ? (
+        //         await (prisma as PrismaClient).course.findMany({
+        //           where: {
+        //             term: 'SUMMER',
+        //           },
+        //         })
+        //       ).map((course) => {
+        //         const meetingTime = (prisma as PrismaClient).meetingTime.findMany({});
 
-                return {
-                  courseNumber: course.code,
-                  subject: course.subject,
-                  sequenceNumber: 'string',
-                  courseTitle: 'string',
-                  meetingTime: {},
-                };
-              })
-            : [];
+        //         return {
+        //           courseNumber: course.code,
+        //           subject: course.subject,
+        //           sequenceNumber: 'string',
+        //           courseTitle: 'string',
+        //           meetingTime: {},
+        //         };
+        //       })
+        //     : [];
 
         const response = await fetch(url, {
           method: 'POST',

--- a/src/types/Schedule.ts
+++ b/src/types/Schedule.ts
@@ -1,5 +1,6 @@
 import { arg, extendType, inputObjectType, intArg, nonNull, objectType } from 'nexus';
 import fetch from 'node-fetch';
+import { CourseIDInput } from './Course';
 import { CourseSection } from './Course/Section';
 import { Date } from './Date';
 import { Response } from './Response';
@@ -9,6 +10,8 @@ export const GenerateScheduleInput = inputObjectType({
   name: 'GenerateScheduleInput',
   definition(t) {
     t.nonNull.int('year');
+    t.nonNull.field('term', { type: Term });
+    t.list.field('courses', { type: CourseIDInput });
   },
 });
 
@@ -163,7 +166,7 @@ export const ScheduleMutation = extendType({
           }),
         });
 
-        return { success: true, message: JSON.stringify(await response.json()) };
+        return { success: true, message: JSON.stringify(response.json()) };
       },
     });
   },


### PR DESCRIPTION
Closes #47 

This PR adds 4 new fields to `generateSchedule` mutation, namely `term`, `courses`, which is a list of CourseInputs, `algorithm1` and `algorithm2`.
Frontend will send us an array of courses with the number of sections needed:
```
courses = [
    {
        code: '499',
        subject: 'SENG',
        section: 3
    },
    {
        code: '426',
        subject: 'SENG',
        section: 2
    }
]
```

This also fixes an unrelated error regarding Preference query return type, and sends the proper format through, in order to fix linting and CI errors.