### PR TITLE
Don't overwrite courses when passing empty array in schedule

### DIFF
--- a/src/utils/schedule.ts
+++ b/src/utils/schedule.ts
@@ -9,6 +9,7 @@ export const createNewCourses = async (
   year: number,
   scheduleId: number
 ) => {
+  // If no courses were passed we the schedule to point to any courses that may have been generated for this term and year
   if (courses.length === 0) {
     await (prisma as PrismaClient).course.updateMany({
       where: {
@@ -22,7 +23,6 @@ export const createNewCourses = async (
   }
 
   const newCourses: (Course & { sectionCount: number; courseInfo: CourseInfo | null })[] = await Promise.all(
-    // If no courses were passed we the schedule to point to any courses that may have been generated for this term and year
     courses.map(async ({ subject, code, section }: { subject: string; code: string; section: number }) => {
       const courseInfo = await (prisma as PrismaClient).courseInfo.findUnique({
         where: {

--- a/src/utils/schedule.ts
+++ b/src/utils/schedule.ts
@@ -9,7 +9,20 @@ export const createNewCourses = async (
   year: number,
   scheduleId: number
 ) => {
+  if (courses.length === 0) {
+    await (prisma as PrismaClient).course.updateMany({
+      where: {
+        year,
+        term,
+      },
+      data: {
+        scheduleID: scheduleId,
+      },
+    });
+  }
+
   const newCourses: (Course & { sectionCount: number; courseInfo: CourseInfo | null })[] = await Promise.all(
+    // If no courses were passed we the schedule to point to any courses that may have been generated for this term and year
     courses.map(async ({ subject, code, section }: { subject: string; code: string; section: number }) => {
       const courseInfo = await (prisma as PrismaClient).courseInfo.findUnique({
         where: {


### PR DESCRIPTION
If a schedule was already generated with courses in the summer, generating a new schedule w/out passing summer courses should update those already generated courses to be in the newly made schedule.

:shipit: 